### PR TITLE
Slight changes to the right auto

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/rightAutoAlt.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/rightAutoAlt.java
@@ -10,6 +10,8 @@ import com.acmerobotics.roadrunner.Vector2d;
 import com.acmerobotics.roadrunner.ftc.Actions;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.util.ElapsedTime;
 
 import org.firstinspires.ftc.teamcode.MecanumDrive;
 import org.firstinspires.ftc.teamcode.hardware.tidev2.Claw;
@@ -42,15 +44,14 @@ public class rightAutoAlt extends LinearOpMode {
         startPose = new Pose2d(14, -61, Math.toRadians(90));
         drive = new MecanumDrive(hardwareMap, startPose);
         TrajectoryActionBuilder build = drive.actionBuilder(startPose)
-                .afterTime(0, viper.autonSlightOut())
                 .afterTime(0, shoulder.autonHC())
-                .afterTime(0.8, viper.autonHangSpecimen())
+                .afterTime(0.7, viper.autonHangSpecimen())
                 .strafeTo(new Vector2d(5, -30))
 
                 //put arm up while strafing
                 //stop and place the sample on the bar
-                .afterTime(0.2, claw.autonOpenClaw())
-                .afterTime(0.3, viper.autonSlightOut())
+                .afterTime(1, claw.autonOpenClaw())
+                .afterTime(1, viper.autonSlightOut())
 
 
 
@@ -130,8 +131,11 @@ public class rightAutoAlt extends LinearOpMode {
         intake.init();
         viper.init();
         claw.init();
+        ElapsedTime timer = new ElapsedTime();
+        boolean inited = false;
 
         while (!isStopRequested() && !opModeIsActive()) {
+
             Actions.runBlocking(new SequentialAction(
                     new InstantAction(() -> shoulder.autonListen()),
                     new InstantAction(() -> viper.autonListen()),
@@ -139,7 +143,17 @@ public class rightAutoAlt extends LinearOpMode {
                     new InstantAction(() -> intake.autonListen()),
                     new InstantAction(() -> claw.autonListen())
             ));
-            viper.listen();
+
+            if (timer.seconds() < 4) {
+                viper.manualSetPower(-0.6);
+            }else if (inited == true) {
+                viper.listen();
+            } else {
+                viper.init();
+                shoulder.setTarget(70);
+                viper.setTarget(40);
+                inited = true;
+            }
 
         }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/rightAutoAlt.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/rightAutoAlt.java
@@ -1,6 +1,10 @@
 package org.firstinspires.ftc.teamcode.autonomous;
 
+import androidx.annotation.NonNull;
+
 import com.acmerobotics.dashboard.config.Config;
+import com.acmerobotics.dashboard.telemetry.TelemetryPacket;
+import com.acmerobotics.roadrunner.Action;
 import com.acmerobotics.roadrunner.InstantAction;
 import com.acmerobotics.roadrunner.ParallelAction;
 import com.acmerobotics.roadrunner.Pose2d;
@@ -32,9 +36,6 @@ public class rightAutoAlt extends LinearOpMode {
     Intake intake = new Intake(this);
     Viper viper = new Viper(this);
     Claw claw = new Claw(this);
-    
-    
-
 
 
 
@@ -43,31 +44,38 @@ public class rightAutoAlt extends LinearOpMode {
     public void runOpMode() throws InterruptedException {
         startPose = new Pose2d(14, -61, Math.toRadians(90));
         drive = new MecanumDrive(hardwareMap, startPose);
-        TrajectoryActionBuilder build = drive.actionBuilder(startPose)
-                .afterTime(0, shoulder.autonHC())
-                .afterTime(0.7, viper.autonHangSpecimen())
-                .strafeTo(new Vector2d(5, -30))
 
+
+        TrajectoryActionBuilder build = drive.actionBuilder(startPose)
                 //put arm up while strafing
                 //stop and place the sample on the bar
-                .afterTime(1, claw.autonOpenClaw())
-                .afterTime(1, viper.autonSlightOut())
+                .afterTime(0, shoulder.autonHC())
+                .afterTime(0.7, viper.autonHangSpecimen())
+                .strafeTo(new Vector2d(5, -28))
+
+                // STEP: post-hang
+                .afterTime(0, shoulder.autonSlightDown())
+                .afterTime(0.1, claw.autonOpenClaw())
+                .afterTime(0.1, viper.autonSlightOut())
 
 
-
+                // STEP: go collect one sample to observation zone
                 .setReversed(true)
                 .splineToSplineHeading(new Pose2d(new Vector2d(26,-43), Math.toRadians(-90)), 0)
                 .afterTime(0, shoulder.autonDown())
 
                 .splineTo(new Vector2d(45, -13), 0)
-
                 .strafeTo(new Vector2d(45,-53))
                 //one in observation zone
+
+                // STEP: go collect another sample to observation zone
                 .strafeTo(new Vector2d(45,-13))
                 .strafeTo(new Vector2d(55,-13))
                 //.strafeTo(new Vector2d(43,-59))
                 //undo ^ if something goes wrong.
                 .strafeTo(new Vector2d(46,-60))
+
+                //TODO: to continue tuning here
 
                 .afterTime(0, claw.autonCloseClaw())
                 .waitSeconds(0.3)
@@ -155,6 +163,7 @@ public class rightAutoAlt extends LinearOpMode {
                 inited = true;
             }
 
+
         }
 
 
@@ -169,6 +178,8 @@ public class rightAutoAlt extends LinearOpMode {
                 elbow.autonListen(),
                 intake.autonListen(),
                 claw.autonListen(),
+
+
                 build.build()
         ));
         PoseStorage.storedPose = drive.pose;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Shoulder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Shoulder.java
@@ -116,6 +116,21 @@ public class Shoulder {
         return new AutonListen();
     }
 
+    public class AutonTargetSetter implements Action {
+        private int autonTarget = 0;
+        public AutonTargetSetter(int t) {
+            this.autonTarget = t;
+        }
+        @Override
+        public boolean run(@NonNull TelemetryPacket packet) {
+            setTarget(autonTarget);
+            return false;
+        }
+    }
+
+    public Action autonSetShoulderTarget(int t) {
+        return new AutonTargetSetter(t);
+    }
 
     public class AutonHC implements Action {
         @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Shoulder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Shoulder.java
@@ -52,7 +52,7 @@ public class Shoulder {
     private PIDFController controller_down;
 
 
-    public static final double p_up = 0.01, p_down = 0.003, i = 0.1, d_up = 0.0004, d_down = 0.0001;
+    public static final double p_up = 0.01, p_down = 0.003, i = 0.1, d_up = 0.0001, d_down = 0.0001;
     public static final double f = 0.00003;
 
     public static int target = 100;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Shoulder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Shoulder.java
@@ -48,9 +48,11 @@ public class Shoulder {
     static final double deadzone = 0.3;
 
 
-    private PIDFController controller;
+    private PIDFController controller_up;
+    private PIDFController controller_down;
 
-    public static final double p = 0.003, i = 0.1, d = 0.0002;
+
+    public static final double p_up = 0.01, p_down = 0.003, i = 0.1, d_up = 0.0004, d_down = 0.0001;
     public static final double f = 0.00003;
 
     public static int target = 100;
@@ -74,8 +76,11 @@ public class Shoulder {
     public void init() {
         // Define and Initialize Motors (note: need to use reference to actual OpMode).
 
-        controller = new PIDFController(p, i, d, f);
-        controller.setTolerance(50, 100);
+        controller_up = new PIDFController(p_up, i, d_up, f);
+        controller_up.setTolerance(50, 100);
+
+        controller_down = new PIDFController(p_down, i, d_down, f);
+        controller_down.setTolerance(50, 100);
 
         shoulder_right = myOpMode.hardwareMap.get(DcMotorEx.class, "left_tower");
         shoulder_left = myOpMode.hardwareMap.get(DcMotorEx.class, "right_tower");
@@ -115,7 +120,7 @@ public class Shoulder {
     public class AutonHC implements Action {
         @Override
         public boolean run(@NonNull TelemetryPacket packet) {
-            setTarget(540);
+            setTarget(530);
             return false;
         }
     }
@@ -132,6 +137,16 @@ public class Shoulder {
     }
     public Action autonDown() {
         return new AutonDown();
+    }
+
+    public Action autonSlightDown() {
+        return new Action() {
+            @Override
+            public boolean run(@NonNull TelemetryPacket packet) {
+                setTarget(500);
+                return false;
+            }
+        };
     }
 
     public class AutonMidDown implements Action {
@@ -213,10 +228,20 @@ public class Shoulder {
 
     public void autoListen() {
         int armPos = shoulder_left.getCurrentPosition();
+        PIDFController controller;
+
+        if (target > armPos) {
+            controller = controller_up;
+        } else {
+            controller = controller_down;
+        }
+
         pidf = controller.calculate(armPos, target);
 
         shoulder_right.setPower(normalize_power(pidf));
         shoulder_left.setPower(normalize_power(pidf));
+
+        sendTelemetry();
     }
 
     public void listen() {
@@ -258,7 +283,9 @@ public class Shoulder {
 
         }
         armPos = shoulder_left.getCurrentPosition();
-        pidf = controller.calculate(armPos, target);
+
+
+        pidf = controller_down.calculate(armPos, target);
 
         if (armPos > 850) {
             pidf = pidf - f;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Viper.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Viper.java
@@ -53,7 +53,7 @@ public class Viper {
 
     private PIDFController controller;
 
-    public static double p = 0.001, i = 0, d = 0;
+    public static double p = 0.001, i = 0.01, d = 0.0;
     public static double f = 0;
 
     public static int target = 0;
@@ -144,7 +144,7 @@ public class Viper {
 
         @Override
         public boolean run(@NonNull TelemetryPacket telemetryPacket) {
-            setTarget(2000);
+            setTarget(2200);
             return false;
         }
     }
@@ -179,11 +179,14 @@ public class Viper {
         pidf = controller.calculate(armPos, target);
 
         viper.setPower(pidf);
-        viper.setPower(pidf);
+
+        sendTelemetry();
+        myOpMode.telemetry.update();
+
     }
 
     public void sendTelemetry() {
-        myOpMode.telemetry.addData("Viper Position:", vipPos);
+        myOpMode.telemetry.addData("Viper Position:", viper.getCurrentPosition());
         myOpMode.telemetry.addData("Power:", pidf);
         myOpMode.telemetry.addData("Target Position:", target);
         myOpMode.telemetry.addData("Viper Max: ", max);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Viper.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Viper.java
@@ -144,7 +144,7 @@ public class Viper {
 
         @Override
         public boolean run(@NonNull TelemetryPacket telemetryPacket) {
-            setTarget(2200);
+            setTarget(3000);
             return false;
         }
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Viper.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Viper.java
@@ -189,6 +189,10 @@ public class Viper {
         myOpMode.telemetry.addData("Viper Max: ", max);
     }
 
+    public void manualSetPower(double pow) {
+        viper.setPower(pow);
+    }
+
     public void listen_simple() {
         pidf = -myOpMode.gamepad2.left_stick_y;
         if (pidf != 0.0) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Viper.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/hardware/tidev2/Viper.java
@@ -127,6 +127,22 @@ public class Viper {
         return new AutonHB();
     }
 
+    public class AutonTargetSetter implements Action {
+        private int autonTarget = 0;
+        public AutonTargetSetter(int t) {
+            this.autonTarget = t;
+        }
+        @Override
+        public boolean run(@NonNull TelemetryPacket packet) {
+            setTarget(autonTarget);
+            return false;
+        }
+    }
+
+    public Action autonSetViperTarget(int t) {
+        return new AutonTargetSetter(t);
+    }
+
     public class AutonSlightOut implements Action {
 
         @Override


### PR DESCRIPTION
Summary of changes:

1. @RedSmile32 on (pull-viper-on-init) pull the viper slide before initializing to zero position, to make auto run more consistent.
2. (separate-shoulder-updown-pid) increase the `p` constant for the up position to 0.01 (while keeping the down position at 0.003).
3. Others:
  * shoulder clipping position at `POS_SHOULDER_HANG=480 ` (lowering` it from 540 since the pid now brings it closer to target).
  * viperslide clipping position at `POS_VIPER_HANG=3300` (increasing it from 2000 allowing it to hang farther to save some milliseconds)
  * create an `AutonTargetSetter` for Shoulder and Viper so we can create Action with varying targets.
  * create `do...` methods so we can reuse codes. For example: `doGoHang`, `doPostHang`, `doClipSampleAndHang`, etc.
  * add a telemetry update during autonomous to see how far the positions are still away from the target.
